### PR TITLE
Use recommended target, install directly

### DIFF
--- a/source/_posts/2014-08-10-how-to-install-composer-on-debian.md
+++ b/source/_posts/2014-08-10-how-to-install-composer-on-debian.md
@@ -13,8 +13,7 @@ To make Composer (globally) available on Debian:
 
 	$ cd /usr/src
 	$ sudo apt-get install curl php5-cli
-	$ curl -sS https://getcomposer.org/installer | sudo php
-	$ sudo mv composer.phar /usr/bin/composer
+	$ curl -sS https://getcomposer.org/installer | sudo php -- --install-dir=/usr/local/bin --filename=composer
 
 Verify installation:
 


### PR DESCRIPTION
1.) Lets better recomment `/usr/local/` for non-distribution-managed software:
See http://unix.stackexchange.com/a/8658 and http://www.pathname.com/fhs/
> `/usr/bin` is for distribution-managed normal user programs.
> `/usr/local/bin` is for normal user programs not managed by the distribution package manager

2.) Composer installer provides commandline switches for install location, thus you can save the extra `mv` command
See `curl -sS https://getcomposer.org/installer | php -- --help`